### PR TITLE
enable Helm to display all icons

### DIFF
--- a/helm-all-the-icons.el
+++ b/helm-all-the-icons.el
@@ -72,7 +72,8 @@
   (interactive)
   (require 'all-the-icons)
   (helm :sources (helm-all-the-icons-sources)
-        :buffer "*helm all the icons*"))
+        :buffer "*helm all the icons*"
+        :candidate-number-limit nil))
 
 (provide 'helm-all-the-icons)
 


### PR DESCRIPTION
Hi,

This is a quick PR to show all icons in the list. This is useful when users don't know the name of the icon that they want to look for, so they can just browse all the icons.

Since there are only less than 3000 icons, so I think that displaying all of them won't affect the performance much.


